### PR TITLE
JT-2: Correct GitHub Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-**jontools** is a collection of various coding projects I've built that serve practical, experimental, or fun purposes. Each tool found here came about either from facing a problem where no existing solution quite fit my needs or simply because I thought it would be interesting to create.
+**jontools** is a collection of various coding projects I've built that serve practical, experimental, or fun purposes.
+Each tool found here came about either from facing a problem where no existing solution quite fit my needs or simply
+because I thought it would be interesting to create.
 
 ## Live
 
@@ -49,7 +51,9 @@
 
 ## Architecture
 
-The frontend is built with React and TypeScript to create a seamless and interactive user experience. The backend, powered by Flask (Python), handles file processing. Docker is utilized to containerize the frontend, backend, and SSL certificate renewal (Certbot) services, facilitating easy deployment and scalability. Content is served through Nginx.
+The frontend is built with React and TypeScript to create a seamless and interactive user experience. The backend,
+powered by Flask (Python), handles file processing. Docker is utilized to containerize the frontend, backend, and SSL
+certificate renewal (Certbot) services, facilitating easy deployment and scalability. Content is served through Nginx.
 
 ## Contact
 
@@ -59,9 +63,8 @@ Visit my homepage at [https://jonlervold.com](https://jonlervold.com).
 
 ## Bug Reports
 
-If you encounter anything not working as expected, please [open an issue on the project's GitHub](https://github.com/).
-
-(JT-2 - Change to correct link)
+If you encounter anything not working as expected, please
+[open an issue on the project's GitHub](https://github.com/jonlervold/jontools).
 
 ## License
 

--- a/frontend/src/components/Body/Home/index.tsx
+++ b/frontend/src/components/Body/Home/index.tsx
@@ -59,8 +59,7 @@ const Home: FC = () => {
       </div>
 
       <div>
-        {/* JT-2 - Change to correct link */}
-        <a href="https://github.com" target="_blank">
+        <a href="https://github.com/jonlervold/jontools" target="_blank">
           jontools GitHub
         </a>
         <div>The GitHub repository for this project.</div>

--- a/frontend/src/components/Footer/index.tsx
+++ b/frontend/src/components/Footer/index.tsx
@@ -21,8 +21,7 @@ const Footer: FC = () => {
 
         <div>//</div>
 
-        {/* JT-2 - Change to correct link */}
-        <a href="https://github.com" target="_blank">
+        <a href="https://github.com/jonlervold/jontools" target="_blank">
           GitHub
         </a>
 

--- a/versionFile.json
+++ b/versionFile.json
@@ -1,5 +1,5 @@
 {
   "major": 1,
   "minor": 0,
-  "patch": 0
+  "patch": 1
 }


### PR DESCRIPTION
https://jonlervold.youtrack.cloud/issue/JT-2
- fix: Change GitHub links to match the public repo.